### PR TITLE
add github issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Story
+
+# Acceptance Criteria
+
+- [ ]
+
+# Screenshots / Video
+
+<details>
+<summary></summary>
+
+</details>
+
+# Testing Instructions and Sample Files
+
+-
+
+# Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Story
+
+Refs
+
+- #issuenumber
+
+# Expected Behavior Before Changes
+
+# Expected Behavior After Changes
+
+# Screenshots / Video
+
+<details>
+<summary></summary>
+
+</details>
+
+# Notes


### PR DESCRIPTION
refs: https://github.com/scientist-softserv/dev-ops/issues/632

Now that we've moved to GitHub, we are adding issue and PR templates to our repos to maintain consistency across our tickets and PRs.