### PR TITLE
Update Thor version dependency

### DIFF
--- a/.github/workflows/rspec-action.yaml
+++ b/.github/workflows/rspec-action.yaml
@@ -19,9 +19,9 @@ jobs:
           path: vendor/bundle
           key: "2.3"
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.59.1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.3"
+          ruby-version: "3.2"
       - name: Dependencies
         run: |
           bundle config path vendor/bundle

--- a/stack_car.gemspec
+++ b/stack_car.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "archive-zip"
   spec.add_runtime_dependency "dotenv"
   spec.add_runtime_dependency "json", "~> 2.3"
-  spec.add_runtime_dependency "thor", "~> 0.20"
+  spec.add_runtime_dependency "thor", "~> 1.4"
 end


### PR DESCRIPTION
**ISSUE**
StackCar installs with a very old version of Thor that call deprecated DidYouMean methods. These calls raise deprecation warnings under Ruby versions >= 3.3 and < 3.4. The method is removed in versions of DidYouMean that run under Ruby >= 3.4.0, causing StackCar failures.

**RESOLUTION**
Update the version on the Thor dependency.

**DETAILS**
Dependencies currently installed by StackCar
```
gem install stack_car
Fetching dotenv-3.1.8.gem
Fetching archive-zip-0.13.1.gem
Fetching thor-0.20.3.gem
Fetching io-like-0.4.0.gem
Fetching stack_car-0.22.0.gem
Successfully installed thor-0.20.3
Successfully installed dotenv-3.1.8
Successfully installed io-like-0.4.0
Successfully installed archive-zip-0.13.1
Successfully installed stack_car-0.22.0
5 gems installed
```

Deprecation warning under Ruby 3.3.9
```
% sc help exec
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Usage:
  sc exec ARGS

Options:
  -s, [--service=SERVICE]
                           # Default: web

wraps docker compose exec web unless --service is used to specify
```

Failure under Ruby 3.4.5
```
% sc help exec
/Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/thor-0.20.3/lib/thor/error.rb:109:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
Did you mean?  DidYouMean::SpellChecker
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/thor-0.20.3/lib/thor/error.rb:1:in '<top (required)>'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/thor-0.20.3/lib/thor/base.rb:4:in '<top (required)>'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/thor-0.20.3/lib/thor.rb:2:in '<top (required)>'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/stack_car-0.22.0/lib/stack_car/proxy.rb:1:in '<top (required)>'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/stack_car-0.22.0/lib/stack_car.rb:3:in 'Kernel#require_relative'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/stack_car-0.22.0/lib/stack_car.rb:3:in '<top (required)>'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from <internal:/Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/stack_car-0.22.0/exe/sc:3:in '<top (required)>'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Kernel#load'
	from /Users/mark/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Gem.activate_and_load_bin_path'
	from /Users/mark/.rbenv/versions/3.4.5/bin/sc:25:in '<main>'
```