### PR TITLE
add args to build

### DIFF
--- a/lib/stack_car/cli.rb
+++ b/lib/stack_car/cli.rb
@@ -96,9 +96,9 @@ module StackCar
 
     method_option :service, default: 'web', type: :string, aliases: '-s'
     desc "build", "builds specified service, defaults to web"
-    def build
+    def build(*args)
       setup
-      run_with_exit("#{dotenv} docker compose build #{options[:service]}")
+      run_with_exit("#{dotenv} docker compose build #{options[:service]} #{args.join(' ')}")
     end
 
     method_option :service, default: 'web', type: :string, aliases: '-s'


### PR DESCRIPTION
allows `sc build --no-cache` and other options to pass straight to `docker compose build`